### PR TITLE
Fix to Matplotlib crash due to inconsistent data types when using latest

### DIFF
--- a/nupic_output.py
+++ b/nupic_output.py
@@ -55,7 +55,7 @@ class NuPICOutput(object):
 
 
   @abstractmethod
-  def write(row, result):
+  def write(self, row, result):
     pass
 
 

--- a/plot_output.py
+++ b/plot_output.py
@@ -117,20 +117,20 @@ class NuPICPlotOutput(object):
     print "initializing %s" % self.name
     anomalyRange = (-0.1, 1.1)
     self.seconds = deque([seconds] * WINDOW, maxlen=WINDOW)
-    for bin in self.bins:
-      self.bin_values[bin] = deque([0.0] * WINDOW, maxlen=WINDOW)
+    for freq_bin in self.bins:
+      self.bin_values[freq_bin] = deque([0.0] * WINDOW, maxlen=WINDOW)
 
-      self.anomaly_likelihoods[bin] = deque([0.0] * WINDOW, maxlen=WINDOW)
+      self.anomaly_likelihoods[freq_bin] = deque([0.0] * WINDOW, maxlen=WINDOW)
       bin_plot, = self._mainGraph.plot(
-        self.seconds, self.bin_values[bin]
+        self.seconds, self.bin_values[freq_bin]
       )
 
-      self.bin_lines[bin] = bin_plot
+      self.bin_lines[freq_bin] = bin_plot
       anomaly_plot, = self._anomalyGraph.plot(
-        self.seconds, self.anomaly_likelihoods[bin]
+        self.seconds, self.anomaly_likelihoods[freq_bin]
       )
       anomaly_plot.axes.set_ylim(anomalyRange)
-      self.anomaly_likelihood_lines[bin] = anomaly_plot
+      self.anomaly_likelihood_lines[freq_bin] = anomaly_plot
 
     self._mainGraph.legend(tuple(self.bins), loc=3)
     self._anomalyGraph.legend(
@@ -159,15 +159,15 @@ class NuPICPlotOutput(object):
 
     self.seconds.append(seconds)
 
-    for i, bin in enumerate(self.bins):
-      self.bin_values[bin].append(bin_values[i])
-      self.anomaly_likelihoods[bin].append(anomaly_likelihoods[i])
+    for i, freq_bin in enumerate(self.bins):
+      self.bin_values[freq_bin].append(bin_values[i])
+      self.anomaly_likelihoods[freq_bin].append(anomaly_likelihoods[i])
 
       # Update main chart data
-      self.bin_lines[bin].set_xdata(self.seconds)
-      self.bin_lines[bin].set_ydata(self.bin_values[bin])
-      self.anomaly_likelihood_lines[bin].set_xdata(self.seconds)
-      self.anomaly_likelihood_lines[bin].set_ydata(self.anomaly_likelihoods[bin])
+      self.bin_lines[freq_bin].set_xdata(self.seconds)
+      self.bin_lines[freq_bin].set_ydata(self.bin_values[freq_bin])
+      self.anomaly_likelihood_lines[freq_bin].set_xdata(self.seconds)
+      self.anomaly_likelihood_lines[freq_bin].set_ydata(self.anomaly_likelihoods[freq_bin])
 
     # Remove previous highlighted regions
     for poly in self._chart_highlights:

--- a/plotter.py
+++ b/plotter.py
@@ -114,14 +114,14 @@ def run(input_dir, audio_file, maximize,
 
     if time.time() <= data_time:
       for i, line in enumerate(next_lines):
-        bin = bins[i]
+        freq_bin = bins[i]
         header = headers[i]
-        bin_value = line[header.index(bin)]
+        bin_value = float(line[header.index(freq_bin)])
         if use_anomaly_score:
           anomaly_key = "anomalyScore"
         else:
           anomaly_key = "anomalyLikelihood"
-        anomaly_likelihood = line[header.index(anomaly_key)]
+        anomaly_likelihood = float(line[header.index(anomaly_key)])
         bin_values.append(bin_value)
         anomaly_likelihoods.append(anomaly_likelihood)
   


### PR DESCRIPTION
Matplotlib.

Replaced use of "bin" as variable with "freq_bin" to avoid clash with
Python internal variable.

Added missing "self" to method in nupic_output.py, even though not used.